### PR TITLE
chore: override default Java compiler and maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
 
         <jboss.developer.drupal.url>http://rhdp-drupal.stage.redhat.com/</jboss.developer.drupal.url>
         <linkXRef>false</linkXRef>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <version.compiler.plugin>3.10.1</version.compiler.plugin>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Override default Java compiler and maven-compiler-plugin

Related issue: https://issues.redhat.com/browse/CRW-3013
![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2022 06 21-13_54_03](https://user-images.githubusercontent.com/1271546/174783839-c6fcef7b-6fdd-4325-9921-bd98bf0f3cd2.png)

